### PR TITLE
Markdown parser now recognizes all bold text syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <h3 align="center">TXT-to-HTML Static Site Converter</h3>
 
 ## Goal
-This is mainly a tool that converts TXT files into static web pages.  A new feature that was added is being able to convert Markdown(MD) files into HTML.  Any ***bold*** text in the MD file will appear in the HTML file as ***bolded***.
+This is mainly a tool that converts TXT files into static web pages.
 
 ## Requirment
 Please first have Node.js installed on your machine. After downloading this tool, please run command "npm i" in command line(such as cmd or PowerShell) while inside the tool's directory to install required npm package(s).
 
 ## Usage
-The user can provide one or more TXT/MD files to convert into HTML file(s) of the same names.<br />
+The user can provide one or more TXT files to convert into HTML file(s) of the same names.<br />
 Sample test files are in "test_files" folder.<br />
 This tool is run by entering commands in command line.<br />
-Use --input or -i to specify path to a TXT/MD file or a folder with TXT/MD files, and this tool will convert them into HTML files in 'dist' folder.<br />
+Use --input or -i to specify path to a TXT file or a folder with TXT files, and this tool will convert them into HTML files in 'dist' folder.<br />
 If the dist folder doesn't exist at the current directory, one will be created. If it exist, it will be deleted first to clean old output before being recreated.<br />
 Example: node SSC -i ./test_files
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <h3 align="center">TXT-to-HTML Static Site Converter</h3>
 
 ## Goal
-This is mainly a tool that converts TXT files into static web pages.
+This is mainly a tool that converts TXT files into static web pages.  A new feature that was added is being able to convert Markdown(MD) files into HTML.  Any ***bold*** text in the MD file will appear in the HTML file as ***bolded***.
 
 ## Requirment
 Please first have Node.js installed on your machine. After downloading this tool, please run command "npm i" in command line(such as cmd or PowerShell) while inside the tool's directory to install required npm package(s).
 
 ## Usage
-The user can provide one or more TXT files to convert into HTML file(s) of the same names.<br />
+The user can provide one or more TXT/MD files to convert into HTML file(s) of the same names.<br />
 Sample test files are in "test_files" folder.<br />
 This tool is run by entering commands in command line.<br />
-Use --input or -i to specify path to a TXT file or a folder with TXT files, and this tool will convert them into HTML files in 'dist' folder.<br />
+Use --input or -i to specify path to a TXT/MD file or a folder with TXT/MD files, and this tool will convert them into HTML files in 'dist' folder.<br />
 If the dist folder doesn't exist at the current directory, one will be created. If it exist, it will be deleted first to clean old output before being recreated.<br />
 Example: node SSC -i ./test_files
 

--- a/SSC.js
+++ b/SSC.js
@@ -116,7 +116,9 @@ function mdReader(source){
    var boldClosed= true;
    //change to each line
    reader.on("line", function(line) {
-      while(line.includes("__") || line.includes("**")){
+
+      // Bold text parsing
+      while (line.includes("__") || line.includes("**")) {
          if (boldClosed) {
             line = line.replace("__", "<b>");
             line = line.replace("**", "<b>");
@@ -124,23 +126,24 @@ function mdReader(source){
             if (line.match(/__/)) {
                line = line.replace("__", "</b>");
                boldClosed = true;
-            } 
+            }
             if (line.match(/\*\*/)) {
                line = line.replace("**", "</b>");
                boldClosed = true;
             }
          }
-         if (!boldClosed){
+         if (!boldClosed) {
             if (line.match(/__/)) {
                line = line.replace("__", "</b>");
                boldClosed = true;
-            } 
+            }
             if (line.match(/\*\*/)) {
                line = line.replace("**", "</b>");
                boldClosed = true;
             }
          }
       }  
+      
       if(line.trim()==""){
          if (lineClosed==false){
             outStream.write("</p>\n\n");

--- a/SSC.js
+++ b/SSC.js
@@ -124,8 +124,8 @@ function mdReader(source){
          }
       }
       else{
-         line = line.replace(/\*\*(.*?)\*\*/, '<b>$1</b>');
-         line = line.replace(/__(.*?)__/, '<b>$1</b>');
+         line = line.replaceAll(/\*\*(.*?)\*\*/g, '<b>$1</b>');
+         line = line.replaceAll(/__(.*?)__/g, '<b>$1</b>');
          if (lineClosed==true){
             outStream.write("  <p>"+line);                    
             lineClosed=false;  

--- a/SSC.js
+++ b/SSC.js
@@ -153,7 +153,6 @@ function mdReader(source){
          }
       }
       else{
-                
          if (lineClosed == true) {
             outStream.write("  <p>" + line);
             lineClosed = false;

--- a/SSC.js
+++ b/SSC.js
@@ -113,8 +113,34 @@ function mdReader(source){
    outStream.write(htmlStart);
 
    var lineClosed=true;//whether line is clsoed with </p>
+   var boldClosed= true;
    //change to each line
    reader.on("line", function(line) {
+      while(line.includes("__") || line.includes("**")){
+         if (boldClosed) {
+            line = line.replace("__", "<b>");
+            line = line.replace("**", "<b>");
+            boldClosed = false;
+            if (line.match(/__/)) {
+               line = line.replace("__", "</b>");
+               boldClosed = true;
+            } 
+            if (line.match(/\*\*/)) {
+               line = line.replace("**", "</b>");
+               boldClosed = true;
+            }
+         }
+         if (!boldClosed){
+            if (line.match(/__/)) {
+               line = line.replace("__", "</b>");
+               boldClosed = true;
+            } 
+            if (line.match(/\*\*/)) {
+               line = line.replace("**", "</b>");
+               boldClosed = true;
+            }
+         }
+      }  
       if(line.trim()==""){
          if (lineClosed==false){
             outStream.write("</p>\n\n");
@@ -124,15 +150,13 @@ function mdReader(source){
          }
       }
       else{
-         line = line.replaceAll(/\*\*(.*?)\*\*/g, '<b>$1</b>');
-         line = line.replaceAll(/__(.*?)__/g, '<b>$1</b>');
-         if (lineClosed==true){
-            outStream.write("  <p>"+line);                    
-            lineClosed=false;  
-         }else{
-            outStream.write(" "+line);
+                
+         if (lineClosed == true) {
+            outStream.write("  <p>" + line);
+            lineClosed = false;
+         } else {
+            outStream.write(" " + line);
          }
-      
       }
    });
 

--- a/SSC.js
+++ b/SSC.js
@@ -125,6 +125,7 @@ function mdReader(source){
       }
       else{
          line = line.replace(/\*\*(.*?)\*\*/, '<b>$1</b>');
+         line = line.replace(/__(.*?)__/, '<b>$1</b>');
          if (lineClosed==true){
             outStream.write("  <p>"+line);                    
             lineClosed=false;  

--- a/test_files/markdown_file.md
+++ b/test_files/markdown_file.md
@@ -1,5 +1,5 @@
-Lorem ipsum dolor sit amet, **consectetur** adipiscing elit. Duis nec nisi sed erat elementum. 
+Lorem ipsum dolor sit amet, __consectetur adipiscing__ elit. Duis nec nisi sed erat elementum. 
 
-Pellentesque in sit amet lacus. In accumsan ipsum a dapibus elementum. Phasellus vitae lacus massa. **Quisque non scelerisque tellus. Maecenas vel consequat ante, eu scelerisque erat. Nulla id mi nec felis** 
+Pellentesque __in sit amet lacus.__ In accumsan ipsum a dapibus elementum. Phasellus vitae lacus massa. **Quisque non scelerisque tellus. Maecenas vel consequat ante, eu scelerisque erat. Nulla id mi nec felis** 
 
 __Fermentum tristique et sed diam. Nam pellentesque cursus metus id posuere. Nulla eget imperdiet risus.__ In in **malesuada lorem.** Nulla vitae nunc pharetra, feugiat magna a, commodo nisl. Ut non ipsum consectetur, porttitor ante quis, __dignissim turpis__.

--- a/test_files/markdown_file.md
+++ b/test_files/markdown_file.md
@@ -2,4 +2,4 @@ Lorem ipsum dolor sit amet, __consectetur adipiscing__ elit. Duis nec nisi sed e
 
 Pellentesque __in sit amet lacus.__ In accumsan ipsum a dapibus elementum. Phasellus vitae lacus massa. **Quisque non scelerisque tellus. Maecenas vel consequat ante, eu scelerisque erat. Nulla id mi nec felis** 
 
-__Fermentum tristique et sed diam. Nam pellentesque cursus metus id posuere. Nulla eget imperdiet risus.__ In in **malesuada lorem.** Nulla vitae nunc pharetra, feugiat magna a, commodo nisl. Ut non ipsum consectetur, porttitor ante quis, __dignissim turpis__.
+__Fermentum tristique et sed diam. Nam pellentesque cursus metus id posuere. Nulla eget imperdiet risus.__ In in **malesuada lorem.** Nulla vitae nunc pharetra, feugiat magna a, commodo nisl. Ut non ipsum consectetur, porttitor ante quis, **dignissim turpis**.

--- a/test_files/markdown_file.md
+++ b/test_files/markdown_file.md
@@ -2,4 +2,4 @@ Lorem ipsum dolor sit amet, **consectetur** adipiscing elit. Duis nec nisi sed e
 
 Pellentesque in sit amet lacus. In accumsan ipsum a dapibus elementum. Phasellus vitae lacus massa. **Quisque non scelerisque tellus. Maecenas vel consequat ante, eu scelerisque erat. Nulla id mi nec felis** 
 
-Fermentum tristique et sed diam. Nam pellentesque cursus metus id posuere. Nulla eget imperdiet risus. In in **malesuada lorem.** Nulla vitae nunc pharetra, feugiat magna a, commodo nisl. Ut non ipsum consectetur, porttitor ante quis, dignissim turpis.
+__Fermentum tristique et sed diam. Nam pellentesque cursus metus id posuere. Nulla eget imperdiet risus.__ In in **malesuada lorem.** Nulla vitae nunc pharetra, feugiat magna a, commodo nisl. Ut non ipsum consectetur, porttitor ante quis, __dignissim turpis__.


### PR DESCRIPTION
# Overview
This pull request is intended to resolve #9 .  It adds support for ``__`` (double underscore) markdown syntax to recognize **bolded** text.

## Features
- Adds support for ``__`` (double underscore) markdown syntax to recognize **bolded** text.
- Support for more than one instance of bolded text per line.
## Code Changes
- ~Added logic for recognizing ```__``` in markdown text. (SSC.js line:128)~
- ~Replaced ```replace()``` with ```replaceAll()``` to recognize multiple bolded text per line. (SSC.js line:127-128)~

### Edit: New Changes
- Added logic for recognizing ```__``` in markdown text. (SSC.js line:121-145)
    - New logic will work across multiple lines in the same paragraph and will recognize multiple bolded text per line. 