### PR TITLE
Add config feature with test file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,18 @@ This shows the help guide.
 `--lang` or `-l`<br />
 Use this to specify the language of the HTML files.<br />
 Example: `-l fr` for French
+
+`--config` or `-c`<br />
+Use this to specify JSON config file that has a list of options.<br />
+If the same option is provided in config file and command line argument, the command line argument will be overridden.<br />
+Example: `-c ./config.json` for below options to be added.<br />
+<span style="color:dimgray;;font-size:20px">config.json</span>
+```json
+{
+  "input": "./test_files",
+  "output": "./out",
+  "stylesheet": "https://cdnjs.cloudflare.com/ajax/libs/tufte-css/1.8.0/tufte.min.css",
+  "lang": "fr-CA",
+  "future-feature": "invalid option will be ignored"
+}
+```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Example: `-l fr` for French
 Use this to specify JSON config file that has a list of options.<br />
 If the same option is provided in config file and command line argument, the command line argument will be overridden.<br />
 Example: `-c ./config.json` for below options to be added.<br />
-<span style="color:dimgray;;font-size:20px">config.json</span>
+<span style="color:dimgray;;font-size:16px">config.json</span>
 ```json
 {
   "input": "./test_files",

--- a/SSC.js
+++ b/SSC.js
@@ -5,8 +5,6 @@ var argv = require('minimist')(process.argv.slice(2));//args using minimist, but
 delete argv['_'];//this tool does not use it
 
 const { version } = require("./package.json");//version
-const { parse } = require("path");
-const { config } = require("process");
 
 var valid=true;//validity of options
 var outputPath="./dist";//output path

--- a/SSC.js
+++ b/SSC.js
@@ -49,7 +49,11 @@ This shows the help guide.\n\n\
 \
 '--lang' or '-l'\n\
 Use this to specify the language of the HTML files.\n\
-Example: -l fr"
+Example: -l fr\n\n\
+\
+'--config' or '-c'\n\
+Use this to specify JSON config file that has a list of options. If the same option is provided in config file and command line argument, the command line argument will be overridden.\n\
+Example: -c ./config.json"
 
 
 function startHtml(title, css, lang) {

--- a/SSC.js
+++ b/SSC.js
@@ -232,7 +232,7 @@ if(argv.config || argv.c){
       optionConfig = JSON.parse(rawContent)
       configOptionValid = true;
    }catch(err){
-      console.log("Could find config json file or could not be parsed.");
+      console.log("Could not find the config json file or could not be parsed.");
       valid = false;
    }
 }

--- a/SSC.js
+++ b/SSC.js
@@ -227,9 +227,14 @@ else{
 let optionConfig;
 let configOptionValid = false;
 if(argv.config || argv.c){
-   const rawContent = fs.readFileSync(argv.c || argv.config).toString();
-   optionConfig = JSON.parse(rawContent)
-   configOptionValid = true;
+   try {
+      const rawContent = fs.readFileSync(argv.c || argv.config).toString();
+      optionConfig = JSON.parse(rawContent)
+      configOptionValid = true;
+   }catch(err){
+      console.log("Could find config json file or could not be parsed.");
+      valid = false;
+   }
 }
 
 if(valid ==false){
@@ -265,8 +270,10 @@ else{
    }
    //==specify stylesheet==
    if(argv.stylesheet || argv.s || configOptionValid){
-      if (configOptionValid && optionConfig['stylesheet']){
-         css=`  <link rel="stylesheet" href="${(optionConfig.stylesheet)+""}">\n`;   
+      if (configOptionValid){
+         if(optionConfig['stylesheet']){
+            css=`  <link rel="stylesheet" href="${(optionConfig.stylesheet)+""}">\n`;   
+         }
       }else{
          css=`  <link rel="stylesheet" href="${(argv.stylesheet || argv.s)+""}">\n`;
       }
@@ -274,8 +281,10 @@ else{
 
    //==specify language==
    if(argv.lang || argv.l || configOptionValid){
-         if (configOptionValid && optionConfig['lang']){
-            lang=optionConfig.lang;
+         if (configOptionValid){
+            if (optionConfig['lang']){
+               lang=optionConfig.lang;
+            }
          }else{
             lang=argv.lang || argv.l;
          }
@@ -283,10 +292,11 @@ else{
 
    //==when one or more file are provided, convert them to html==
    if(argv.input || argv.i || configOptionValid){
-
       let source;
-      if (configOptionValid && optionConfig['input']){
-         source = optionConfig.input;
+      if (configOptionValid){
+         if (optionConfig['input']){
+            source = optionConfig.input;
+         }
       }else{
          source = (argv.input || argv.i)+""; 
       }

--- a/ssg-config.json
+++ b/ssg-config.json
@@ -1,0 +1,7 @@
+{
+  "input": "./test_files",
+  "stylesheet": "link1",
+  "output": "./dist",
+  "lang": "fr-CA",
+  "future-feature": "should be ignored for now"
+}


### PR DESCRIPTION
I have implemented `--config` option. I tried to minimize the amount of change and follow your error handling and conventions. But please feel free to let me know if you have a different direction. 

I have tested many scenarios as below. 
1. `-c` or `--config` option with a valid JSON file
2. `-c` option with valid JSON file with other options to test override
3. `-c` option with valid JSON file without `input` or `output` information

I also tested some of the edge cases. Let me know if you find anything while you are checking. 

Thank you 