### PR TITLE
Fix htmlFormat test text and add config tests

### DIFF
--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,0 +1,22 @@
+const { outputPath, css, lang, help } = require("../src/config");
+
+describe("config tests", () => {
+  test("outputPath, css, lang, and help variables should all exist as string", async () => {
+    expect(typeof outputPath).toBe("string");
+    expect(typeof css).toBe("string");
+    expect(typeof lang).toBe("string");
+    expect(typeof help).toBe("string");
+  });
+
+  test("Output path should default to './dist'", async () => {
+    expect(outputPath).toBe("./dist");
+  });
+
+  test("CSS link value should default to be empty", async () => {
+    expect(css).toBe("");
+  });
+
+  test("Default language should be 'en-CA'", async () => {
+    expect(lang).toBe("en-CA");
+  });
+});

--- a/tests/htmlFormat.test.js
+++ b/tests/htmlFormat.test.js
@@ -21,11 +21,11 @@ describe("startHtml tests", () => {
  </head>\n\
  <body>\n`;
 
-  test("startHtml: no css should be present when it's not provided", async () => {
+  test("no css should be present when it's not provided", async () => {
     expect(startHtml("ABC", "", "ABC")).toBe(startHtmlNoCss);
   });
 
-  test("startHtml: all arguments are provided", async () => {
+  test("all arguments are provided", async () => {
     expect(
       startHtml(
         "ABC",


### PR DESCRIPTION
## Description
Fix htmlFormat test text and add config tests

## Changes
Delete `startHtml` from test texts of `htmlFormat.test.js`
Add `config.test.js` to test `config.js`